### PR TITLE
fix: render sync false for asset type and chain name

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -26,8 +26,10 @@ services:
         generateValue: true
       - key: HOLAPLEX_WALLET_ASSET_TYPE
         value: SOL
+        sync: false
       - key: NEXT_PUBLIC_CHAIN_NAME
         value: "Solana"
+        sync: false
       - key: HOLAPLEX_API_ENDPOINT
         value: https://api.holaplex.com/graphql
       - key: DATABASE_URL


### PR DESCRIPTION
I missed setting sync: false - we need this so render doesn't override changing to polygon